### PR TITLE
add clipper to RCInflator

### DIFF
--- a/JSFX/Audio/RCInflator.jsfx
+++ b/JSFX/Audio/RCInflator.jsfx
@@ -44,20 +44,34 @@ s0 = abs(spl0);
 s0 *= in_db;
 clip ? (
   s0 = s0 > 1 ? 1 : s0;
+  sgn = sign(spl0);
+) : (
+  s0 = 0.5 * s0 - 0.5;
+  frac = s0 - floor(s0);
+  s0 = 2 * abs(0.5 - frac);
+  frac = spl0 * 0.25 - 0.5;
+  sgn = sign(frac - floor(frac) - 0.5);
 );
 s0_2 = s0 * s0;
 s0_3 = s0_2 * s0;
 s0 = curveA * s0 + curveB * s0_2 + curveC * s0_3 - curveD * (s0_2 - 2 * s0_3 + s0_2 * s0_2);
 s0 *= out_db;
-spl0 = sign(spl0) * s0 * wet + spl0 * dry;
+spl0 = sgn * s0 * wet + spl0 * dry;
 
 s1 = abs(spl1);
 s1 *= in_db;
 clip ? (
   s1 = s1 > 1 ? 1 : s1;
+  sgn = sign(spl1);
+) : (
+  s1 = 0.5 * s1 - 0.5;
+  frac = s1 - floor(s1);
+  s1 = 2 * abs(0.5 - frac);
+  frac = spl1 * 0.25 - 0.5;
+  sgn = sign(frac - floor(frac) - 0.5);
 );
 s1_2 = s1 * s1;
 s1_3 = s1_2 * s1;
 s1 = curveA * s1 + curveB * s1_2 + curveC * s1_3 - curveD * (s1_2 - 2 * s1_3 + s1_2 * s1_2);
 s1 *= out_db;
-spl1 = sign(spl1) * s1 * wet + spl1 * dry;
+spl1 = sgn * s1 * wet + spl1 * dry;

--- a/JSFX/Audio/RCInflator.jsfx
+++ b/JSFX/Audio/RCInflator.jsfx
@@ -3,7 +3,7 @@ JSFX Name: RCInflator
 Author: RCJacH
 Release Date: Aug 2021
 Link: https://github.com/RCJacH/ReaScripts
-Version: 0.2
+Version: 0.4
 Reference:
   tviler
   Sony Oxford
@@ -24,10 +24,10 @@ slider6:clip=0<0,1,1{No,Yes}>Clip
 @init
 
 @slider
-in_db = 2 ^ (slider1 / 6);
+in_db = exp(0.11512925464970229 * slider1);
 wet = slider2 * 0.01;
 dry = 1 - wet;
-out_db = 2 ^ (slider5 / 6);
+out_db = exp(0.11512925464970229 * slider5);
 
 curvepct = curve * 0.01;
 // 1 + (curve + 50) / 100
@@ -40,38 +40,30 @@ curveC = curvepct - 0.5;
 curveD = 0.0625 - curve * 0.0025 + (curve * curve) * 0.000025;
 
 @sample
-s0 = abs(spl0);
-s0 *= in_db;
-clip ? (
-  s0 = s0 > 1 ? 1 : s0;
-  sgn = sign(spl0);
-) : (
-  s0 = 0.5 * s0 - 0.5;
-  frac = s0 - floor(s0);
-  s0 = 2 * abs(0.5 - frac);
-  frac = spl0 * 0.25 - 0.5;
-  sgn = sign(frac - floor(frac) - 0.5);
+function apply_waveshaper(in)
+local(s0, s0_2, s0_3, sgn, frac)
+global(curveA, curveB, curveC, curveD,
+       clip, dry, in_db, out_db, wet)
+(
+  s0 = abs(in);
+  s0 *= in_db;
+  clip ? (
+    s0 = s0 > 1 ? 1 : s0;
+    sgn = sign(in);
+  ) : (
+    s0 = 0.5 * s0 - 0.5;
+    frac = s0 - floor(s0);
+    s0 = 2 * abs(0.5 - frac);
+    frac = in * 0.25 - 0.5;
+    sgn = sign(frac - floor(frac) - 0.5);
+  );
+  s0_2 = s0 * s0;
+  s0_3 = s0_2 * s0;
+  s0 = curveA * s0 + curveB * s0_2 + curveC * s0_3 - curveD * (s0_2 - 2 * s0_3 + s0_2 * s0_2);
+  s0 *= out_db;
+  
+  sgn * s0 * wet + in * dry
 );
-s0_2 = s0 * s0;
-s0_3 = s0_2 * s0;
-s0 = curveA * s0 + curveB * s0_2 + curveC * s0_3 - curveD * (s0_2 - 2 * s0_3 + s0_2 * s0_2);
-s0 *= out_db;
-spl0 = sgn * s0 * wet + spl0 * dry;
 
-s1 = abs(spl1);
-s1 *= in_db;
-clip ? (
-  s1 = s1 > 1 ? 1 : s1;
-  sgn = sign(spl1);
-) : (
-  s1 = 0.5 * s1 - 0.5;
-  frac = s1 - floor(s1);
-  s1 = 2 * abs(0.5 - frac);
-  frac = spl1 * 0.25 - 0.5;
-  sgn = sign(frac - floor(frac) - 0.5);
-);
-s1_2 = s1 * s1;
-s1_3 = s1_2 * s1;
-s1 = curveA * s1 + curveB * s1_2 + curveC * s1_3 - curveD * (s1_2 - 2 * s1_3 + s1_2 * s1_2);
-s1 *= out_db;
-spl1 = sgn * s1 * wet + spl1 * dry;
+spl0 = apply_waveshaper(spl0);
+spl1 = apply_waveshaper(spl1);

--- a/JSFX/Audio/RCInflator.jsfx
+++ b/JSFX/Audio/RCInflator.jsfx
@@ -19,6 +19,7 @@ slider2:100<0, 100, 0.1>Effect (%)
 slider3:curve=0<-50, 50, 0.0001>Curve
 
 slider5:0<-60, 6, 0.1>Output (dB)
+slider6:clip=0<0,1,1{No,Yes}>Clip
 
 @init
 
@@ -41,6 +42,9 @@ curveD = 0.0625 - curve * 0.0025 + (curve * curve) * 0.000025;
 @sample
 s0 = abs(spl0);
 s0 *= in_db;
+clip ? (
+  s0 = s0 > 1 ? 1 : s0;
+);
 s0_2 = s0 * s0;
 s0_3 = s0_2 * s0;
 s0 = curveA * s0 + curveB * s0_2 + curveC * s0_3 - curveD * (s0_2 - 2 * s0_3 + s0_2 * s0_2);
@@ -49,6 +53,9 @@ spl0 = sign(spl0) * s0 * wet + spl0 * dry;
 
 s1 = abs(spl1);
 s1 *= in_db;
+clip ? (
+  s1 = s1 > 1 ? 1 : s1;
+);
 s1_2 = s1 * s1;
 s1_3 = s1_2 * s1;
 s1 = curveA * s1 + curveB * s1_2 + curveC * s1_3 - curveD * (s1_2 - 2 * s1_3 + s1_2 * s1_2);


### PR DESCRIPTION
This adds a clipper that prevents the signal from exceeding the input bounds. It also adds wrapping of the waveshaper and deduplicates some code (waveshaper is only coded once but applied to both channels).

Just to explain what the wrapping code for the sine does. It uses a triangle wave based on the input (tri(abs(input)), to look up the correct position in the waveshaping curve. Then, it uses a sawtooth wave to reconstruct what sign the output should have at that point.